### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Node.js CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Ngaremaina/Ticketing-App/security/code-scanning/1](https://github.com/Ngaremaina/Ticketing-App/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out the repository and installs dependencies, it only needs `contents: read` permissions. This change will ensure that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
